### PR TITLE
feat: add voting flow

### DIFF
--- a/backend/VotingSystem.DataContracts/SelectionDto.cs
+++ b/backend/VotingSystem.DataContracts/SelectionDto.cs
@@ -1,0 +1,11 @@
+namespace VotingSystem.DataContracts;
+
+/// <summary>
+/// A single choice the voter made for one race.
+/// Used during review and submit.
+/// </summary>
+public class SelectionDto
+{
+    public int RaceId { get; set; }
+    public int ChoiceId { get; set; }
+}

--- a/backend/VotingSystem.DataContracts/SubmitBallotRequest.cs
+++ b/backend/VotingSystem.DataContracts/SubmitBallotRequest.cs
@@ -1,0 +1,11 @@
+namespace VotingSystem.DataContracts;
+
+/// <summary>
+/// What the frontend sends when a voter submits their finished ballot.
+/// </summary>
+public class SubmitBallotRequest
+{
+    public int VoterId { get; set; }
+    public int ElectionId { get; set; }
+    public List<SelectionDto> Selections { get; set; } = new();
+}

--- a/backend/VotingSystem.DataContracts/SubmitBallotResponse.cs
+++ b/backend/VotingSystem.DataContracts/SubmitBallotResponse.cs
@@ -1,0 +1,12 @@
+namespace VotingSystem.DataContracts;
+
+/// <summary>
+/// Backend response after a ballot submit attempt.
+/// ConfirmationCode is set on success so the voter can verify their ballot later.
+/// </summary>
+public class SubmitBallotResponse
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public Guid? ConfirmationCode { get; set; }
+}

--- a/backend/VotingSystem.DataContracts/ValidationResult.cs
+++ b/backend/VotingSystem.DataContracts/ValidationResult.cs
@@ -1,0 +1,13 @@
+namespace VotingSystem.DataContracts;
+
+/// <summary>
+/// Generic validation outcome used by engines and managers.
+/// </summary>
+public class ValidationResult
+{
+    public bool IsValid { get; set; }
+    public string ErrorMessage { get; set; } = string.Empty;
+
+    public static ValidationResult Valid() => new() { IsValid = true };
+    public static ValidationResult Invalid(string message) => new() { IsValid = false, ErrorMessage = message };
+}

--- a/backend/VotingSystem.Engines/BallotValidationEngine.cs
+++ b/backend/VotingSystem.Engines/BallotValidationEngine.cs
@@ -1,0 +1,51 @@
+using VotingSystem.DataContracts;
+
+namespace VotingSystem.Engines;
+
+/// <summary>
+/// Validates a voter's selections against the ballot they were given.
+/// </summary>
+public class BallotValidationEngine : IBallotValidationEngine
+{
+    public ValidationResult Validate(BallotDto ballot, List<SelectionDto> selections)
+    {
+        // rule 1: must have at least one selection
+        if (selections == null || selections.Count == 0)
+        {
+            return ValidationResult.Invalid("No selections were submitted.");
+        }
+
+        // rule 2: no duplicate races (can't pick two mayors)
+        var raceIds = selections.Select(s => s.RaceId).ToList();
+        if (raceIds.Count != raceIds.Distinct().Count())
+        {
+            return ValidationResult.Invalid("Duplicate selection for a race.");
+        }
+
+        // rule 3: every race on the ballot must have a selection
+        foreach (var race in ballot.Races)
+        {
+            if (!raceIds.Contains(race.RaceId))
+            {
+                return ValidationResult.Invalid($"Missing selection for race: {race.RaceName}.");
+            }
+        }
+
+        // rule 4 and 5: every selection must match a real race and a real choice in that race
+        foreach (var selection in selections)
+        {
+            var race = ballot.Races.FirstOrDefault(r => r.RaceId == selection.RaceId);
+            if (race == null)
+            {
+                return ValidationResult.Invalid($"Selection for unknown race: {selection.RaceId}.");
+            }
+
+            if (!race.Choices.Any(c => c.ChoiceId == selection.ChoiceId))
+            {
+                return ValidationResult.Invalid($"Selection for unknown choice in race: {race.RaceName}.");
+            }
+        }
+
+        return ValidationResult.Valid();
+    }
+}

--- a/backend/VotingSystem.Engines/IBallotValidationEngine.cs
+++ b/backend/VotingSystem.Engines/IBallotValidationEngine.cs
@@ -1,0 +1,12 @@
+using VotingSystem.DataContracts;
+
+namespace VotingSystem.Engines;
+
+/// <summary>
+/// Checks that a set of selections is valid against the current ballot.
+/// Pure logic, no database access.
+/// </summary>
+public interface IBallotValidationEngine
+{
+    ValidationResult Validate(BallotDto ballot, List<SelectionDto> selections);
+}

--- a/backend/VotingSystem.Managers/IVotingSessionManager.cs
+++ b/backend/VotingSystem.Managers/IVotingSessionManager.cs
@@ -1,0 +1,14 @@
+using VotingSystem.DataContracts;
+
+namespace VotingSystem.Managers;
+
+/// <summary>
+/// Handles the submit ballot flow.
+/// </summary>
+public interface IVotingSessionManager
+{
+    /// <summary>
+    /// Submit a finished ballot. Validates, checks for duplicate voting, and saves.
+    /// </summary>
+    Task<SubmitBallotResponse> SubmitBallotAsync(SubmitBallotRequest request);
+}

--- a/backend/VotingSystem.Managers/VotingSessionManager.cs
+++ b/backend/VotingSystem.Managers/VotingSessionManager.cs
@@ -1,0 +1,72 @@
+using VotingSystem.DataContracts;
+using VotingSystem.Engines;
+using VotingSystem.ResourceAccess;
+
+namespace VotingSystem.Managers;
+
+/// <summary>
+/// Coordinates the submit ballot flow.
+/// Loads the ballot, checks for duplicate voting, validates, saves.
+/// </summary>
+public class VotingSessionManager : IVotingSessionManager
+{
+    private readonly IBallotManager _ballotManager;
+    private readonly IVoterAccessor _voterAccessor;
+    private readonly IBallotValidationEngine _validationEngine;
+    private readonly IVoteAccessor _voteAccessor;
+
+    public VotingSessionManager(
+        IBallotManager ballotManager,
+        IVoterAccessor voterAccessor,
+        IBallotValidationEngine validationEngine,
+        IVoteAccessor voteAccessor)
+    {
+        _ballotManager = ballotManager;
+        _voterAccessor = voterAccessor;
+        _validationEngine = validationEngine;
+        _voteAccessor = voteAccessor;
+    }
+
+    public async Task<SubmitBallotResponse> SubmitBallotAsync(SubmitBallotRequest request)
+    {
+        // step 1: make sure there is an active ballot to submit against
+        var ballot = await _ballotManager.GetActiveBallotAsync();
+        if (ballot == null)
+        {
+            return Fail("No active election to submit to.");
+        }
+
+        // step 2: prevent duplicate voting
+        var alreadyVoted = await _voterAccessor.HasVotedInElectionAsync(request.VoterId, request.ElectionId);
+        if (alreadyVoted)
+        {
+            return Fail("You have already voted in this election.");
+        }
+
+        // step 3: validate the selections against the ballot
+        var validation = _validationEngine.Validate(ballot, request.Selections);
+        if (!validation.IsValid)
+        {
+            return Fail(validation.ErrorMessage);
+        }
+
+        // step 4: map selections to Vote entities and save
+        var votes = request.Selections.Select(s => new Vote
+        {
+            RaceId = s.RaceId,
+            CandidateId = s.ChoiceId
+        }).ToList();
+
+        var confirmationCode = await _voteAccessor.SubmitBallotAsync(request.VoterId, request.ElectionId, votes);
+
+        return new SubmitBallotResponse
+        {
+            Success = true,
+            Message = "Ballot submitted successfully.",
+            ConfirmationCode = confirmationCode
+        };
+    }
+
+    private static SubmitBallotResponse Fail(string message) =>
+        new() { Success = false, Message = message };
+}

--- a/backend/VotingSystem.Tests/BallotValidationEngineTests.cs
+++ b/backend/VotingSystem.Tests/BallotValidationEngineTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VotingSystem.DataContracts;
+using VotingSystem.Engines;
+
+namespace VotingSystem.Tests;
+
+[TestClass]
+public class BallotValidationEngineTests
+{
+    private BallotValidationEngine _engine = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _engine = new BallotValidationEngine();
+    }
+
+    // small helper to build a test ballot
+    private static BallotDto MakeBallot() => new()
+    {
+        ElectionId = 1,
+        ElectionName = "Test",
+        Races = new List<RaceDto>
+        {
+            new RaceDto
+            {
+                RaceId = 10, RaceName = "Mayor", RaceType = "Candidate",
+                Choices = new List<ChoiceDto>
+                {
+                    new ChoiceDto { ChoiceId = 100, ChoiceName = "Lil Red" },
+                    new ChoiceDto { ChoiceId = 101, ChoiceName = "Herbie" }
+                }
+            },
+            new RaceDto
+            {
+                RaceId = 20, RaceName = "Prop 1", RaceType = "YesNo",
+                Choices = new List<ChoiceDto>
+                {
+                    new ChoiceDto { ChoiceId = 200, ChoiceName = "Yes" },
+                    new ChoiceDto { ChoiceId = 201, ChoiceName = "No" }
+                }
+            }
+        }
+    };
+
+    [TestMethod]
+    public void Validate_AllRacesCovered_ReturnsValid()
+    {
+        var selections = new List<SelectionDto>
+        {
+            new SelectionDto { RaceId = 10, ChoiceId = 100 },
+            new SelectionDto { RaceId = 20, ChoiceId = 201 }
+        };
+
+        var result = _engine.Validate(MakeBallot(), selections);
+
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void Validate_DuplicateRaceSelection_ReturnsInvalid()
+    {
+        var selections = new List<SelectionDto>
+        {
+            new SelectionDto { RaceId = 10, ChoiceId = 100 },
+            new SelectionDto { RaceId = 10, ChoiceId = 101 },
+            new SelectionDto { RaceId = 20, ChoiceId = 200 }
+        };
+
+        var result = _engine.Validate(MakeBallot(), selections);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.ErrorMessage.Contains("Duplicate"));
+    }
+
+    [TestMethod]
+    public void Validate_MissingRaceSelection_ReturnsInvalid()
+    {
+        // only selecting mayor, missing prop 1
+        var selections = new List<SelectionDto>
+        {
+            new SelectionDto { RaceId = 10, ChoiceId = 100 }
+        };
+
+        var result = _engine.Validate(MakeBallot(), selections);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.ErrorMessage.Contains("Missing"));
+    }
+
+    [TestMethod]
+    public void Validate_UnknownRaceId_ReturnsInvalid()
+    {
+        var selections = new List<SelectionDto>
+        {
+            new SelectionDto { RaceId = 10, ChoiceId = 100 },
+            new SelectionDto { RaceId = 20, ChoiceId = 200 },
+            new SelectionDto { RaceId = 999, ChoiceId = 1 }  // race not on ballot
+        };
+
+        var result = _engine.Validate(MakeBallot(), selections);
+
+        Assert.IsFalse(result.IsValid);
+    }
+
+    [TestMethod]
+    public void Validate_ChoiceNotInRace_ReturnsInvalid()
+    {
+        var selections = new List<SelectionDto>
+        {
+            new SelectionDto { RaceId = 10, ChoiceId = 200 },  // "Yes" isn't a mayor choice
+            new SelectionDto { RaceId = 20, ChoiceId = 201 }
+        };
+
+        var result = _engine.Validate(MakeBallot(), selections);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.ErrorMessage.Contains("unknown choice"));
+    }
+
+    [TestMethod]
+    public void Validate_EmptySelections_ReturnsInvalid()
+    {
+        var result = _engine.Validate(MakeBallot(), new List<SelectionDto>());
+
+        Assert.IsFalse(result.IsValid);
+    }
+}

--- a/backend/VotingSystem.Tests/VotingSessionManagerTests.cs
+++ b/backend/VotingSystem.Tests/VotingSessionManagerTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VotingSystem.DataContracts;
+using VotingSystem.Engines;
+using VotingSystem.Managers;
+using VotingSystem.ResourceAccess;
+
+namespace VotingSystem.Tests;
+
+[TestClass]
+public class VotingSessionManagerTests
+{
+    private class FakeBallotManager : IBallotManager
+    {
+        public BallotDto? BallotToReturn { get; set; }
+        public Task<BallotDto?> GetActiveBallotAsync() => Task.FromResult(BallotToReturn);
+    }
+
+    private class FakeVoterAccessor : IVoterAccessor
+    {
+        public bool HasVoted { get; set; }
+        public Task<Voter?> GetVoterByUsernameAsync(string username) => Task.FromResult<Voter?>(null);
+        public Task<bool> HasVotedInElectionAsync(int voterId, int electionId) => Task.FromResult(HasVoted);
+    }
+
+    private class FakeValidationEngine : IBallotValidationEngine
+    {
+        public ValidationResult ResultToReturn { get; set; } = ValidationResult.Valid();
+        public ValidationResult Validate(BallotDto ballot, List<SelectionDto> selections) => ResultToReturn;
+    }
+
+    private class FakeVoteAccessor : IVoteAccessor
+    {
+        public Guid CodeToReturn { get; set; } = Guid.NewGuid();
+        public Task<Guid> SubmitBallotAsync(int voterId, int electionId, List<Vote> selections) => Task.FromResult(CodeToReturn);
+        public Task<IEnumerable<Vote>> GetVotesByConfirmationCodeAsync(Guid confirmationCode) =>
+            Task.FromResult<IEnumerable<Vote>>(new List<Vote>());
+    }
+
+    private static BallotDto MakeBallot() => new()
+    {
+        ElectionId = 1,
+        ElectionName = "Test",
+        Races = new List<RaceDto>
+        {
+            new RaceDto { RaceId = 10, RaceName = "Mayor", RaceType = "Candidate" }
+        }
+    };
+
+    private static SubmitBallotRequest MakeRequest() => new()
+    {
+        VoterId = 1,
+        ElectionId = 1,
+        Selections = new List<SelectionDto> { new SelectionDto { RaceId = 10, ChoiceId = 100 } }
+    };
+
+    [TestMethod]
+    public async Task SubmitBallotAsync_ValidSubmission_ReturnsSuccessWithConfirmationCode()
+    {
+        var expectedCode = Guid.NewGuid();
+        var manager = new VotingSessionManager(
+            new FakeBallotManager { BallotToReturn = MakeBallot() },
+            new FakeVoterAccessor { HasVoted = false },
+            new FakeValidationEngine { ResultToReturn = ValidationResult.Valid() },
+            new FakeVoteAccessor { CodeToReturn = expectedCode }
+        );
+
+        var response = await manager.SubmitBallotAsync(MakeRequest());
+
+        Assert.IsTrue(response.Success);
+        Assert.AreEqual(expectedCode, response.ConfirmationCode);
+    }
+
+    [TestMethod]
+    public async Task SubmitBallotAsync_NoActiveElection_ReturnsFailure()
+    {
+        var manager = new VotingSessionManager(
+            new FakeBallotManager { BallotToReturn = null },
+            new FakeVoterAccessor(),
+            new FakeValidationEngine(),
+            new FakeVoteAccessor()
+        );
+
+        var response = await manager.SubmitBallotAsync(MakeRequest());
+
+        Assert.IsFalse(response.Success);
+        Assert.IsTrue(response.Message.Contains("No active"));
+    }
+
+    [TestMethod]
+    public async Task SubmitBallotAsync_AlreadyVoted_ReturnsFailure()
+    {
+        var manager = new VotingSessionManager(
+            new FakeBallotManager { BallotToReturn = MakeBallot() },
+            new FakeVoterAccessor { HasVoted = true },
+            new FakeValidationEngine(),
+            new FakeVoteAccessor()
+        );
+
+        var response = await manager.SubmitBallotAsync(MakeRequest());
+
+        Assert.IsFalse(response.Success);
+        Assert.IsTrue(response.Message.Contains("already voted"));
+    }
+
+    [TestMethod]
+    public async Task SubmitBallotAsync_InvalidBallot_ReturnsFailure()
+    {
+        var manager = new VotingSessionManager(
+            new FakeBallotManager { BallotToReturn = MakeBallot() },
+            new FakeVoterAccessor { HasVoted = false },
+            new FakeValidationEngine { ResultToReturn = ValidationResult.Invalid("Missing selection.") },
+            new FakeVoteAccessor()
+        );
+
+        var response = await manager.SubmitBallotAsync(MakeRequest());
+
+        Assert.IsFalse(response.Success);
+        Assert.AreEqual("Missing selection.", response.Message);
+    }
+}

--- a/backend/VotingSystem.View/Program.cs
+++ b/backend/VotingSystem.View/Program.cs
@@ -17,10 +17,12 @@ builder.Services.AddScoped<IVoteAccessor>(_ => new VoteAccessor(connectionString
 
 // engines (pure logic, no state, safe as singleton)
 builder.Services.AddSingleton<IAuthEngine, AuthEngine>();
+builder.Services.AddSingleton<IBallotValidationEngine, BallotValidationEngine>();
 
 // managers (orchestration)
 builder.Services.AddScoped<IAuthManager, AuthManager>();
 builder.Services.AddScoped<IBallotManager, BallotManager>();
+builder.Services.AddScoped<IVotingSessionManager, VotingSessionManager>();
 
 var app = builder.Build();
 
@@ -39,6 +41,14 @@ app.MapGet("/api/ballot", async (IBallotManager ballotManager) =>
 {
     var ballot = await ballotManager.GetActiveBallotAsync();
     return ballot is null ? Results.NotFound() : Results.Ok(ballot);
+});
+
+// POST /api/submit-ballot - takes SubmitBallotRequest, returns SubmitBallotResponse
+// always returns 200, success/failure in the response body
+app.MapPost("/api/submit-ballot", async (SubmitBallotRequest request, IVotingSessionManager sessionManager) =>
+{
+    var response = await sessionManager.SubmitBallotAsync(request);
+    return Results.Ok(response);
 });
 
 app.Run();


### PR DESCRIPTION
## Description                                                                                                                                                                          
                                                                                                                                                                                          
  Voting flow. Voter can submit a finished ballot and get a confirmation code back. Handles validation, duplicate prevention, and database save in one transaction.                       
                                                                          
## Type of Change                                                                                                                                                                       
                                                                            
  - [x] New feature                                                                                                                                                                       
                                                                            
## Changes Made                                                         
                                                                          
  - SelectionDto, SubmitBallotRequest, SubmitBallotResponse, ValidationResult                                                                                                             
  - BallotValidationEngine with 5 rules (no empty, no dupes, all races covered, known race, known choice)
  - VotingSessionManager orchestrates the submit flow                                                                                                                                     
  - POST /api/submit-ballot route                                                                                                                                                         
  - 10 new unit tests (6 for validation engine, 4 for session manager)                                                                                                                    
  - DI registrations for the new engine and manager                                                                                                                                       
                                                                                                                                                                                          
## How to Test                                                          
                                                                                                                                                                                          
  1. `dotnet build` passes                                                                                                                                                                
  2. `dotnet test` passes (28 tests)                                      
  3. Run the backend, then:                                                                                                                                                               
     - POST /api/submit-ballot with full valid selections, returns success with a GUID                                                                                                    
     - POST the same voter again, returns "already voted" failure                                                                                                                         
     - POST with a missing race, returns "missing selection" failure                                                                                                                      
                                                                                                                                                                                          
## Checklist                                                                                                                                                                            
                                                                            
  - [x] Code follows the project's style guidelines                                                                                                                                       
  - [x] Self-reviewed the code for obvious errors                           
  - [x] Added or updated tests where applicable                                                                                                                                           
  - [x] Existing tests pass locally                                                                                                                                                       
  - [x] Updated documentation if needed                                                                                                                                                   
  - [x] No new warnings or console errors introduced                                                                                                                                      
                                                                                                                                                                                          
## Related Issues                                                       
                                                                                                                                                                                          
  Closes #24                                                                
  Closes #26                                                              
  Closes #27                                                              
  Closes #28                                                                                                                                                                              
  Closes #29                                                              
  Closes #30