### PR TITLE
feat: add duplicate vote engine

### DIFF
--- a/backend/VotingSystem.Engines/DuplicateVoteEngine.cs
+++ b/backend/VotingSystem.Engines/DuplicateVoteEngine.cs
@@ -1,0 +1,20 @@
+using VotingSystem.DataContracts;
+
+namespace VotingSystem.Engines;
+
+/// <summary>
+/// Enforces the "one vote per election" rule.
+/// The manager fetches the hasAlreadyVoted flag from the accessor and passes it here.
+/// </summary>
+public class DuplicateVoteEngine : IDuplicateVoteEngine
+{
+    public ValidationResult Check(bool hasAlreadyVoted)
+    {
+        if (hasAlreadyVoted)
+        {
+            return ValidationResult.Invalid("You have already voted in this election.");
+        }
+
+        return ValidationResult.Valid();
+    }
+}

--- a/backend/VotingSystem.Engines/IDuplicateVoteEngine.cs
+++ b/backend/VotingSystem.Engines/IDuplicateVoteEngine.cs
@@ -1,0 +1,15 @@
+using VotingSystem.DataContracts;
+
+namespace VotingSystem.Engines;
+
+/// <summary>
+/// Checks whether a voter is allowed to vote based on their prior voting status.
+/// Pure logic, no database access.
+/// </summary>
+public interface IDuplicateVoteEngine
+{
+    /// <summary>
+    /// Returns valid if the voter has not voted yet, invalid if they have.
+    /// </summary>
+    ValidationResult Check(bool hasAlreadyVoted);
+}

--- a/backend/VotingSystem.Managers/VotingSessionManager.cs
+++ b/backend/VotingSystem.Managers/VotingSessionManager.cs
@@ -12,17 +12,20 @@ public class VotingSessionManager : IVotingSessionManager
 {
     private readonly IBallotManager _ballotManager;
     private readonly IVoterAccessor _voterAccessor;
+    private readonly IDuplicateVoteEngine _duplicateVoteEngine;
     private readonly IBallotValidationEngine _validationEngine;
     private readonly IVoteAccessor _voteAccessor;
 
     public VotingSessionManager(
         IBallotManager ballotManager,
         IVoterAccessor voterAccessor,
+        IDuplicateVoteEngine duplicateVoteEngine,
         IBallotValidationEngine validationEngine,
         IVoteAccessor voteAccessor)
     {
         _ballotManager = ballotManager;
         _voterAccessor = voterAccessor;
+        _duplicateVoteEngine = duplicateVoteEngine;
         _validationEngine = validationEngine;
         _voteAccessor = voteAccessor;
     }
@@ -36,11 +39,12 @@ public class VotingSessionManager : IVotingSessionManager
             return Fail("No active election to submit to.");
         }
 
-        // step 2: prevent duplicate voting
+        // step 2: duplicate vote check (accessor fetches status, engine decides)
         var alreadyVoted = await _voterAccessor.HasVotedInElectionAsync(request.VoterId, request.ElectionId);
-        if (alreadyVoted)
+        var duplicateCheck = _duplicateVoteEngine.Check(alreadyVoted);
+        if (!duplicateCheck.IsValid)
         {
-            return Fail("You have already voted in this election.");
+            return Fail(duplicateCheck.ErrorMessage);
         }
 
         // step 3: validate the selections against the ballot

--- a/backend/VotingSystem.Tests/DuplicateVoteEngineTests.cs
+++ b/backend/VotingSystem.Tests/DuplicateVoteEngineTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VotingSystem.Engines;
+
+namespace VotingSystem.Tests;
+
+[TestClass]
+public class DuplicateVoteEngineTests
+{
+    private DuplicateVoteEngine _engine = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _engine = new DuplicateVoteEngine();
+    }
+
+    [TestMethod]
+    public void Check_VoterHasNotVoted_ReturnsValid()
+    {
+        // first vote should be allowed
+        var result = _engine.Check(hasAlreadyVoted: false);
+
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void Check_VoterAlreadyVoted_ReturnsInvalid()
+    {
+        // second vote should be blocked
+        var result = _engine.Check(hasAlreadyVoted: true);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.IsTrue(result.ErrorMessage.Contains("already voted"));
+    }
+
+    [TestMethod]
+    public void Check_VoterAlreadyVoted_MessageIsClear()
+    {
+        var result = _engine.Check(hasAlreadyVoted: true);
+
+        Assert.AreEqual("You have already voted in this election.", result.ErrorMessage);
+    }
+}

--- a/backend/VotingSystem.Tests/VotingSessionManagerTests.cs
+++ b/backend/VotingSystem.Tests/VotingSessionManagerTests.cs
@@ -28,6 +28,12 @@ public class VotingSessionManagerTests
         public ValidationResult Validate(BallotDto ballot, List<SelectionDto> selections) => ResultToReturn;
     }
 
+    private class FakeDuplicateVoteEngine : IDuplicateVoteEngine
+    {
+        public ValidationResult ResultToReturn { get; set; } = ValidationResult.Valid();
+        public ValidationResult Check(bool hasAlreadyVoted) => ResultToReturn;
+    }
+
     private class FakeVoteAccessor : IVoteAccessor
     {
         public Guid CodeToReturn { get; set; } = Guid.NewGuid();
@@ -60,6 +66,7 @@ public class VotingSessionManagerTests
         var manager = new VotingSessionManager(
             new FakeBallotManager { BallotToReturn = MakeBallot() },
             new FakeVoterAccessor { HasVoted = false },
+            new FakeDuplicateVoteEngine { ResultToReturn = ValidationResult.Valid() },
             new FakeValidationEngine { ResultToReturn = ValidationResult.Valid() },
             new FakeVoteAccessor { CodeToReturn = expectedCode }
         );
@@ -76,6 +83,7 @@ public class VotingSessionManagerTests
         var manager = new VotingSessionManager(
             new FakeBallotManager { BallotToReturn = null },
             new FakeVoterAccessor(),
+            new FakeDuplicateVoteEngine(),
             new FakeValidationEngine(),
             new FakeVoteAccessor()
         );
@@ -92,6 +100,7 @@ public class VotingSessionManagerTests
         var manager = new VotingSessionManager(
             new FakeBallotManager { BallotToReturn = MakeBallot() },
             new FakeVoterAccessor { HasVoted = true },
+            new FakeDuplicateVoteEngine { ResultToReturn = ValidationResult.Invalid("You have already voted in this election.") },
             new FakeValidationEngine(),
             new FakeVoteAccessor()
         );
@@ -108,6 +117,7 @@ public class VotingSessionManagerTests
         var manager = new VotingSessionManager(
             new FakeBallotManager { BallotToReturn = MakeBallot() },
             new FakeVoterAccessor { HasVoted = false },
+            new FakeDuplicateVoteEngine(),
             new FakeValidationEngine { ResultToReturn = ValidationResult.Invalid("Missing selection.") },
             new FakeVoteAccessor()
         );

--- a/backend/VotingSystem.View/Program.cs
+++ b/backend/VotingSystem.View/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddScoped<IVoteAccessor>(_ => new VoteAccessor(connectionString
 // engines (pure logic, no state, safe as singleton)
 builder.Services.AddSingleton<IAuthEngine, AuthEngine>();
 builder.Services.AddSingleton<IBallotValidationEngine, BallotValidationEngine>();
+builder.Services.AddSingleton<IDuplicateVoteEngine, DuplicateVoteEngine>();
 
 // managers (orchestration)
 builder.Services.AddScoped<IAuthManager, AuthManager>();


### PR DESCRIPTION
## Description                                                                                                                                                                          

Duplicate vote engine split out of the voting session manager. Now a real engine like the ballot validation one. Manager grabs the status from the accessor, engine decides if voting is allowed.                                                                                                                                                                                          
                                                                                                                                                                                          
## Type of Change                                                       
                                                                                                                                                                                          
  - [x] Refactoring (no functional changes)                                                                                                                                               
  - [x] New feature                                                                                                                                                                       
                                                                          
## Changes Made                                                                                                                                                                         
                                                                            
  - IDuplicateVoteEngine interface and DuplicateVoteEngine implementation 
  - Refactored VotingSessionManager to use the engine for duplicate check                                                                                                                 
  - 3 unit tests: first vote passes, second vote fails, error message clear
  - DI registration in Program.cs                                                                                                                                                         
                                                                                                                                                                                          
## How to Test                                                                                                                                                                          
                                                                                                                                                                                          
  1. `dotnet build` passes                                                  
  2. `dotnet test` passes (31 tests total, 3 new)                                                                                                                                         
                                                                          
## Checklist                                                                                                                                                                            
                                                                            
  - [x] Code follows the project's style guidelines                                                                                                                                       
  - [x] Self-reviewed the code for obvious errors                           
  - [x] Added or updated tests where applicable                           
  - [x] Existing tests pass locally                                                                                                                                                       
  - [x] Updated documentation if needed                                                                                                                                                   
  - [x] No new warnings or console errors introduced                                                                                                                                      
                                                                                                                                                                                          
## Related Issues                                                                                                                                                                       
                                                                                                                                                                                          
  Closes #36                                                                                                                                                                              
  Closes #37